### PR TITLE
Add S-Maxage in Permalink Route

### DIFF
--- a/includes/RestPermalink.php
+++ b/includes/RestPermalink.php
@@ -100,7 +100,17 @@ class RestPermalink
 
         $serialized = $this->serialize($post, $request);
 
-        return rest_ensure_response($serialized);
+        $cacheLimit = (defined('DECOUPLED_PERMALINK_S_MAX_AGE') && !empty(DECOUPLED_PERMALINK_S_MAX_AGE) )
+            ? DECOUPLED_PERMALINK_S_MAX_AGE
+            : 60*10; //defaults at 10 minutes
+        
+        $headers = [
+            'Cache-Control' => 'max-age=0, s-maxage='.$cacheLimit,
+        ];
+
+        $response =  new \WP_REST_Response($serialized, 200, $headers);
+
+        return rest_ensure_response($response);
     }
 
     function getTemplate($post) {

--- a/includes/templates/settings.php
+++ b/includes/templates/settings.php
@@ -39,6 +39,16 @@
                 </td>
             </tr>
             <tr>
+                <th>
+                    <label for="decoupled_cache_permalink_smaxage">Cache Permalink Server Max Age (for CDN)</label>
+                </th>
+                <td>
+                    <?php echo (defined('DECOUPLED_PERMALINK_S_MAX_AGE') && !empty(DECOUPLED_PERMALINK_S_MAX_AGE) ) ? 
+                    DECOUPLED_PERMALINK_S_MAX_AGE . ' seconds'
+                    : '10 minutes (default)'; ?>
+                </td>
+            </tr>
+            <tr>
                 <td colspan="2">
                     <h3>URL Settings</h3>
                 </td>
@@ -56,7 +66,7 @@
             <?php 
                 if ( (defined('DECOUPLED_CLIENT_URL') 
                     && !empty(DECOUPLED_CLIENT_URL) ) 
-                    && !filter_var(DECOUPLED_CLIENT_URL, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED)) { 
+                    && !filter_var(DECOUPLED_CLIENT_URL, FILTER_VALIDATE_URL)) { 
             ?>
             <tr>
                 <th style="color: red;" colspan="2">


### PR DESCRIPTION
Allows control the `Cache-Control: s-maxage` header in the responses of the permalink route. Default is 10 minutes and can be adjusted setting the `DECOUPLED_PERMALINK_S_MAX_AGE` environment variable (in seconds)

Also removed deprecated `FILTER_FLAG_SCHEME_REQUIRED` from the settings page